### PR TITLE
fix(auth): wait for first-run probe before routing setup vs login

### DIFF
--- a/src/components/auth/auth-gate.tsx
+++ b/src/components/auth/auth-gate.tsx
@@ -30,6 +30,7 @@ export function AuthGate({ children }: { children: ReactNode }) {
   const hydrate = useAuth((s) => s.hydrate)
   const user = useAuth((s) => s.user)
   const needsSetup = useAuth((s) => s.needsSetup)
+  const setupProbed = useAuth((s) => s.setupProbed)
   const loadConversations = useConversations((s) => s.load)
   const loadProjects = useProjects((s) => s.load)
   const loadModels = useModels((s) => s.load)
@@ -86,14 +87,23 @@ export function AuthGate({ children }: { children: ReactNode }) {
     void loadModels()
   }, [status, user?.id, loadConversations, loadProjects, loadModels])
 
-  // Loading state — quick shimmer (auth check + initial paint).
+  // Loading shimmer (auth check + initial paint) — reused while the first-run
+  // probe is still pending so we never route on a not-yet-known needsSetup.
+  const shimmer = (
+    <div className="min-h-svh w-full flex items-center justify-center text-[var(--color-fg-subtle)] text-sm">
+      <span className="inline-block size-4 rounded-full border-2 border-[var(--color-fg-faint)] border-r-transparent animate-[spin_900ms_linear_infinite]" />
+    </div>
+  )
   if (status === 'idle' || status === 'authenticating') {
     if (isPublic(location.pathname)) return <>{children}</>
-    return (
-      <div className="min-h-svh w-full flex items-center justify-center text-[var(--color-fg-subtle)] text-sm">
-        <span className="inline-block size-4 rounded-full border-2 border-[var(--color-fg-faint)] border-r-transparent animate-[spin_900ms_linear_infinite]" />
-      </div>
-    )
+    return shimmer
+  }
+  // First-run probe not resolved yet — deciding setup-vs-login on the default
+  // (needsSetup=false) is exactly what flickered a fresh deploy /setup → /login.
+  // Public pages render immediately; protected paths wait for the probe.
+  if (!setupProbed) {
+    if (isPublic(location.pathname)) return <>{children}</>
+    return shimmer
   }
 
   // First-run: a deployment with no users routes everything to the setup screen

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -37,6 +37,10 @@ interface AuthState {
   /** True when the deployment has no users yet — the app routes to the first-run
    *  setup screen (create the first admin) instead of login (§ first-run setup). */
   needsSetup: boolean
+  /** False until the first-run probe (/public/needs-setup) has resolved at least
+   *  once. The gate waits for this before choosing setup-vs-login, so a fresh
+   *  deploy doesn't flicker /setup → /login on the default (false) value. */
+  setupProbed: boolean
   /** Set when registration returns verification_required — drives the code UI. */
   pendingVerification: string | null
   /** Set when password login returns totp_required — drives the 2FA code UI. */
@@ -71,6 +75,7 @@ export const useAuth = create<AuthState>((set, get) => ({
   signupOpen: true,
   captchaRequired: false,
   needsSetup: false,
+  setupProbed: false,
   pendingVerification: null,
   pendingTwoFactor: null,
 
@@ -114,18 +119,19 @@ export const useAuth = create<AuthState>((set, get) => ({
       if (!isLatestAuthOp(seq)) return
       set({ user: null, status: 'unauthenticated' })
     } finally {
-      try {
-        const r = await authApi.signupOpen()
-        if (isLatestAuthOp(seq)) set({ signupOpen: r.open, captchaRequired: r.captcha_required })
-      } catch {
-        /* ignore */
-      }
-      // First-run probe: a fresh deployment (zero users) routes to /setup.
-      try {
-        const s = await authApi.needsSetup()
-        if (isLatestAuthOp(seq)) set({ needsSetup: s.needs_setup })
-      } catch {
-        /* ignore */
+      // First-run probe: a fresh deployment (zero users) routes to /setup. Probe
+      // it in PARALLEL with signup-open so a slow/failed sibling call can't delay
+      // the routing decision, and mark it resolved either way so the AuthGate
+      // stops waiting (otherwise the gate is stuck on the default needsSetup).
+      const [signup, setup] = await Promise.allSettled([authApi.signupOpen(), authApi.needsSetup()])
+      if (isLatestAuthOp(seq)) {
+        if (signup.status === 'fulfilled') {
+          set({ signupOpen: signup.value.open, captchaRequired: signup.value.captcha_required })
+        }
+        if (setup.status === 'fulfilled') {
+          set({ needsSetup: setup.value.needs_setup })
+        }
+        set({ setupProbed: true })
       }
     }
   },


### PR DESCRIPTION
AuthGate chose setup-vs-login from `needsSetup`, which defaults to false and was only set after the /public/needs-setup probe resolved — and that probe was sequenced behind signup-open in hydrate's finally. On a fresh deploy the guard saw needsSetup=false in that window and bounced /setup -> /login, stranding the first-run setup screen even though the server reported needs_setup=true.

- Probe needs-setup in PARALLEL with signup-open (Promise.allSettled) so a slow or failed sibling call can't delay the routing decision.
- Add a `setupProbed` flag, set once the probe resolves either way.
- Hold AuthGate on the loading shimmer (protected paths) / render public pages until setupProbed is true, so it never routes on an unknown needsSetup. Fresh deploy now goes / -> shimmer -> /setup with no login flicker.