### PR TITLE
feat(files): storage-full toast links straight to the Files page

### DIFF
--- a/src/components/chat/composer.tsx
+++ b/src/components/chat/composer.tsx
@@ -43,7 +43,9 @@ import { useMediaQuery } from '@/hooks/use-media-query'
 import { useModels } from '@/store/models'
 import { useAuth } from '@/store/auth'
 import { useComposerPrefs } from '@/store/composer-prefs'
+import { useNavigate } from 'react-router-dom'
 import { api, apiUpload, ApiError } from '@/api/client'
+import { toastStorageQuotaFull } from '@/lib/quota-toast'
 import type { ApiAttachment, ApiConversationFile, ApiDocument } from '@/api/types'
 import { toast } from '@/hooks/use-toast'
 import { cn, uid, modKey } from '@/lib/utils'
@@ -225,6 +227,7 @@ export function Composer({
   modelPickerInHeader = false,
 }: ComposerProps) {
   const { t } = useTranslation('chat')
+  const navigate = useNavigate()
   const mode = useComposerPrefs((s) => s.mode)
   const setMode = useComposerPrefs((s) => s.setMode)
   // §verify: when on, the answer is fact-checked by a second model this turn.
@@ -499,8 +502,8 @@ export function Composer({
     } catch (e) {
       setAttachments((s) => s.filter((a) => a.id !== local.id))
       if (e instanceof ApiError && e.status === 507) {
-        // § user files page: group storage quota exhausted.
-        toast.error(t('composer.storageQuotaFull', { defaultValue: 'Storage is full — free up space in Files and try again.' }))
+        // § user files page: group storage quota exhausted — link to /files.
+        toastStorageQuotaFull(navigate)
       } else {
         toast.error(t('composer.uploadFailed', { defaultValue: 'Upload failed' }), e instanceof Error ? e.message : undefined)
       }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -61,7 +61,8 @@
     "styleHeading": "Image style",
     "styleNone": "None",
     "noStyles": "No styles configured.",
-    "storageQuotaFull": "Storage is full — free up space in Files and try again."
+    "storageQuotaFull": "Storage is full — free up space in Files and try again.",
+    "storageQuotaAction": "Clean up space"
   },
   "assistant": "Aivory",
   "thinking": "Thinking",

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -61,7 +61,8 @@
     "styleHeading": "Style d'image",
     "styleNone": "Aucun",
     "noStyles": "Aucun style configuré.",
-    "storageQuotaFull": "Stockage plein — libérez de l'espace dans Fichiers puis réessayez."
+    "storageQuotaFull": "Stockage plein — libérez de l'espace dans Fichiers puis réessayez.",
+    "storageQuotaAction": "Libérer de l'espace"
   },
   "assistant": "Aivory",
   "thinking": "Réflexion",

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -61,7 +61,8 @@
     "styleHeading": "画像スタイル",
     "styleNone": "なし",
     "noStyles": "スタイルがありません。",
-    "storageQuotaFull": "ストレージが満杯のためアップロードできません。「ファイル」ページで空きを作ってから再試行してください。"
+    "storageQuotaFull": "ストレージが満杯のためアップロードできません。「ファイル」ページで空きを作ってから再試行してください。",
+    "storageQuotaAction": "空き容量を作る"
   },
   "assistant": "Aivory",
   "thinking": "思考中",

--- a/src/i18n/locales/zh-Hant/chat.json
+++ b/src/i18n/locales/zh-Hant/chat.json
@@ -61,7 +61,8 @@
     "styleHeading": "圖片風格",
     "styleNone": "無",
     "noStyles": "尚無風格。",
-    "storageQuotaFull": "儲存空間已滿,無法上傳。請先到「檔案」頁清理後再試。"
+    "storageQuotaFull": "儲存空間已滿,無法上傳。請先到「檔案」頁清理後再試。",
+    "storageQuotaAction": "去清理空間"
   },
   "assistant": "Aivory",
   "thinking": "思考中",

--- a/src/i18n/locales/zh/chat.json
+++ b/src/i18n/locales/zh/chat.json
@@ -61,7 +61,8 @@
     "styleHeading": "图片风格",
     "styleNone": "无",
     "noStyles": "暂无风格。",
-    "storageQuotaFull": "存储空间已满,无法上传。请先到「文件」页清理后再试。"
+    "storageQuotaFull": "存储空间已满,无法上传。请先到「文件」页清理后再试。",
+    "storageQuotaAction": "去清理空间"
   },
   "assistant": "Aivory",
   "thinking": "思考中",

--- a/src/lib/quota-toast.ts
+++ b/src/lib/quota-toast.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared "storage quota exceeded" toast (§ user files page): every upload
+ * entry point shows the same message with a one-click jump to /files, so
+ * users always know WHERE to free up space.
+ */
+import i18n from '@/i18n'
+import { toast } from '@/hooks/use-toast'
+
+export function toastStorageQuotaFull(navigate: (to: string) => void) {
+  toast.custom({
+    title: i18n.t('chat:composer.storageQuotaFull', {
+      defaultValue: 'Storage is full — free up space in Files and try again.',
+    }),
+    variant: 'danger',
+    duration: 8000,
+    action: {
+      label: i18n.t('chat:composer.storageQuotaAction', { defaultValue: 'Clean up space' }),
+      onClick: () => navigate('/files'),
+    },
+  })
+}

--- a/src/pages/kb/KnowledgeBaseDetail.tsx
+++ b/src/pages/kb/KnowledgeBaseDetail.tsx
@@ -35,6 +35,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { ContentHeader } from '@/components/layout/content-header'
 import { toast } from '@/hooks/use-toast'
+import { toastStorageQuotaFull } from '@/lib/quota-toast'
 import { formatRelativeDate, cn } from '@/lib/utils'
 import { envNum } from '@/lib/env-config'
 
@@ -119,7 +120,11 @@ export default function KnowledgeBaseDetail() {
       setDraft({ filename: '', content: '' })
       await load()
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : t('kb:detail.uploadFailed'))
+      if (e instanceof ApiError && e.status === 507) {
+        toastStorageQuotaFull(navigate)
+      } else {
+        toast.error(e instanceof ApiError ? e.message : t('kb:detail.uploadFailed'))
+      }
     }
   }
 
@@ -145,7 +150,11 @@ export default function KnowledgeBaseDetail() {
       setOpen(false)
       await load()
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : t('kb:detail.uploadFailed'))
+      if (e instanceof ApiError && e.status === 507) {
+        toastStorageQuotaFull(navigate)
+      } else {
+        toast.error(e instanceof ApiError ? e.message : t('kb:detail.uploadFailed'))
+      }
     } finally {
       setUploading(false)
       setUploadJob(null)


### PR DESCRIPTION
The quota-exceeded message now carries a 'Clean up space' action that navigates to /files, shown from both the chat composer and KB document uploads (shared helper), so users know where to free up space.