### PR TITLE
fix(chat): four composer/home/message-list UX bugs

### DIFF
--- a/src/components/chat/composer.tsx
+++ b/src/components/chat/composer.tsx
@@ -13,6 +13,7 @@
  */
 import { activeWorkspaceId } from '@/store/workspaces'
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import {
   ArrowUp,
@@ -123,6 +124,24 @@ interface ComposerProps {
 
 const MAX_LEN = envNum('VITE_AIVORY_MAX_LEN', 12_000)
 const EMPTY_PARAM_VALUES: Record<string, unknown> = {}
+
+// Backend file ids already committed to a SENT message, shared across every
+// composer instance (module scope, not a per-instance ref). Sending the FIRST
+// message from the home screen navigates to the thread, which mounts a FRESH
+// composer whose draft-file restore (listDraftFiles) can race the backend's
+// commit of the just-sent file and re-add the image that was already sent. The
+// existing per-instance `committedAttachmentIds` ref can't guard a different
+// instance, so committed ids are tracked here too. Upload ids are unique, so a
+// committed id never legitimately reappears as a fresh draft; the size cap only
+// bounds memory across a long session.
+const committedFileIds = new Set<string>()
+function markFileCommitted(id: string) {
+  committedFileIds.add(id)
+  if (committedFileIds.size > 256) {
+    const oldest = committedFileIds.values().next().value
+    if (oldest !== undefined) committedFileIds.delete(oldest)
+  }
+}
 
 // Speech-to-text capability is shared across composer instances. Besides the
 // provider, the backend reports whether its required credentials exist so the
@@ -483,8 +502,15 @@ export function Composer({
   const attachmentScopeRef = useRef(conversationId)
   const [restoringAttachments, setRestoringAttachments] = useState(Boolean(conversationId))
   const [kbList, setKBList] = useState<{ id: string; name: string }[]>([])
-  // Drag-and-drop file upload over the composer surface.
+  // Drag-and-drop file upload. `dragOver` is driven by WINDOW-level listeners
+  // (see the effect below) so a file can be dropped ANYWHERE on the page, not
+  // only onto the composer surface. dragDepthRef balances nested
+  // dragenter/dragleave so the full-screen overlay doesn't flicker as the
+  // pointer crosses child elements. handleAttachRef exposes the latest attach
+  // handler to those window listeners without re-subscribing them each render.
   const [dragOver, setDragOver] = useState(false)
+  const dragDepthRef = useRef(0)
+  const handleAttachRef = useRef<(files: FileList | null) => Promise<number>>(() => Promise.resolve(0))
   // Narrow screens collapse every secondary action into a single "+" menu
   // (Gemini/ChatGPT-mobile pattern) so the row never overflows and tap targets
   // stay large. 639px = Tailwind's `sm` breakpoint minus 1.
@@ -554,6 +580,52 @@ export function Composer({
     el.addEventListener('wheel', onWheel, { passive: false })
     return () => el.removeEventListener('wheel', onWheel)
   }, [hasAttachments])
+  // §full-screen drop: accept image/file drops anywhere in the window, not just
+  // on the composer. Window-level listeners raise a full-viewport overlay while
+  // a file is dragged in and route the drop through the same handleAttach path.
+  // Only ONE composer is ever mounted (home / thread / project routes are
+  // mutually exclusive), so a single window listener set never double-handles.
+  useEffect(() => {
+    const hasFiles = (e: DragEvent) => Array.from(e.dataTransfer?.types ?? []).includes('Files')
+    const onDragEnter = (e: DragEvent) => {
+      if (!hasFiles(e)) return
+      dragDepthRef.current += 1
+      setDragOver(true)
+    }
+    const onDragOver = (e: DragEvent) => {
+      if (!hasFiles(e)) return
+      // preventDefault marks the whole window a valid drop target and stops the
+      // browser from navigating to a file dropped outside the composer.
+      e.preventDefault()
+      if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'
+      // Self-heal the overlay if a dragenter was missed (some browsers skip it
+      // when the drag originates outside the document).
+      if (dragDepthRef.current === 0) dragDepthRef.current = 1
+      setDragOver(true)
+    }
+    const onDragLeave = (e: DragEvent) => {
+      if (!hasFiles(e)) return
+      dragDepthRef.current = Math.max(0, dragDepthRef.current - 1)
+      if (dragDepthRef.current === 0) setDragOver(false)
+    }
+    const onDrop = (e: DragEvent) => {
+      if (!hasFiles(e)) return
+      e.preventDefault()
+      dragDepthRef.current = 0
+      setDragOver(false)
+      if (e.dataTransfer?.files?.length) void handleAttachRef.current(e.dataTransfer.files)
+    }
+    window.addEventListener('dragenter', onDragEnter)
+    window.addEventListener('dragover', onDragOver)
+    window.addEventListener('dragleave', onDragLeave)
+    window.addEventListener('drop', onDrop)
+    return () => {
+      window.removeEventListener('dragenter', onDragEnter)
+      window.removeEventListener('dragover', onDragOver)
+      window.removeEventListener('dragleave', onDragLeave)
+      window.removeEventListener('drop', onDrop)
+    }
+  }, [])
   useEffect(() => {
     const timers = pollTimers.current
     return () => {
@@ -934,6 +1006,9 @@ export function Composer({
       pollTimers.current.clear()
       attachments.forEach((a) => {
         committedAttachmentIds.current.add(a.id)
+        // Also record at module scope so the freshly-mounted thread composer
+        // (first send from home) filters this id out of its draft-file restore.
+        markFileCommitted(a.id)
         if (a.previewUrl && a.previewUrl.startsWith('blob:')) URL.revokeObjectURL(a.previewUrl)
       })
       setAttachments([])
@@ -1104,8 +1179,15 @@ export function Composer({
           return [
             ...current,
             // Skip anything already present OR already sent — a stale restore
-            // fetch must never resurrect a just-committed attachment.
-            ...restored.filter((item) => !present.has(item.id) && !committedAttachmentIds.current.has(item.id)),
+            // fetch must never resurrect a just-committed attachment (checked
+            // both per-instance and at module scope so a first send from the home
+            // screen doesn't bounce the image into the new thread's composer).
+            ...restored.filter(
+              (item) =>
+                !present.has(item.id) &&
+                !committedAttachmentIds.current.has(item.id) &&
+                !committedFileIds.has(item.id),
+            ),
           ]
         })
         for (const file of files) {
@@ -1219,6 +1301,9 @@ export function Composer({
     const done = await Promise.all(list.map((file, idx) => uploadAttachment(file, additions[idx], scopeId)))
     return done.filter(Boolean).length
   }
+  // Keep the window-level drag listeners calling the current closure (it reads
+  // conversationId / kbIds / ensureConversationId), without re-subscribing them.
+  handleAttachRef.current = handleAttach
 
   // Codex-style long-text overflow (§4.11-B3): text past MAX_LEN becomes a .txt
   // attachment instead of being blocked. The backend line-gates it — small
@@ -1549,22 +1634,6 @@ export function Composer({
 
   return (
     <div
-      onDragOver={(e) => {
-        // Only react to file drags; let text/selection drags pass through.
-        if (!Array.from(e.dataTransfer.types).includes('Files')) return
-        e.preventDefault()
-        setDragOver(true)
-      }}
-      onDragLeave={(e) => {
-        // Ignore leave events fired when crossing into a child element.
-        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setDragOver(false)
-      }}
-      onDrop={(e) => {
-        if (!Array.from(e.dataTransfer.types).includes('Files')) return
-        e.preventDefault()
-        setDragOver(false)
-        if (e.dataTransfer.files?.length) void handleAttach(e.dataTransfer.files)
-      }}
       className={cn(
         'group/composer relative min-w-0 w-full max-w-full',
         // Calm Gemini-style pill on phones (rounder, no resting shadow); the
@@ -1575,15 +1644,26 @@ export function Composer({
         dragOver && 'border-[var(--color-accent)] shadow-[var(--shadow-md)]',
       )}
     >
-      {/* Drag-and-drop overlay — shown while a file is dragged over the composer. */}
-      {dragOver && (
-        <div className="pointer-events-none absolute inset-0 z-[var(--z-raised)] grid place-items-center rounded-[16px] bg-[var(--color-accent-soft)]/80 backdrop-blur-[1px]">
-          <span className="inline-flex items-center gap-2 text-sm font-medium text-[var(--color-accent)]">
-            <Paperclip size={15} aria-hidden />
-            {t('composer.dropHint', { defaultValue: 'Drop files to attach' })}
-          </span>
-        </div>
-      )}
+      {/* Full-screen drag-and-drop overlay — shown while a file is dragged
+          anywhere over the window. Portalled to <body> so it stays viewport-fixed
+          even when an ancestor (e.g. ChatHome's GSAP-animated wrapper) carries an
+          inline transform that would otherwise become the fixed containing block.
+          pointer-events-none: the window listeners own the drop, and the overlay
+          must never intercept it. */}
+      {dragOver &&
+        createPortal(
+          <div className="pointer-events-none fixed inset-0 z-[var(--z-max)] grid place-items-center bg-[var(--color-overlay)] p-6 backdrop-blur-[2px] animate-[fade-in_var(--duration-base)_var(--ease-out)]">
+            <div className="flex flex-col items-center gap-3 rounded-[18px] border-2 border-dashed border-[var(--color-accent)] bg-[var(--color-surface)]/95 px-8 py-7 shadow-[var(--shadow-lg)]">
+              <span className="grid size-12 place-items-center rounded-full bg-[var(--color-accent-soft)] text-[var(--color-accent)]">
+                <ImageIcon size={22} aria-hidden />
+              </span>
+              <span className="text-[15px] font-medium text-[var(--color-fg)]">
+                {t('composer.dropAnywhere', { defaultValue: 'Drop anywhere to attach' })}
+              </span>
+            </div>
+          </div>,
+          document.body,
+        )}
 
       {/* Attachments preview. The armed-mode (research) state is shown by the
           toolbar button below, so we don't repeat a chip above the input.

--- a/src/components/chat/message-list.tsx
+++ b/src/components/chat/message-list.tsx
@@ -263,6 +263,29 @@ export function MessageList({ conversation, scrollToMessageId, jumpKey }: Messag
     [convId, deleteMessage],
   )
 
+  // §first-exchange: the opening question and its answer anchor the conversation
+  // and must never be deletable. Deletion is round-based — removing EITHER the
+  // question or its answer drops the whole exchange — so both the first user turn
+  // and its first assistant reply are protected. Derived by role (not index 0/1)
+  // so a leading system turn can't shift the target. Only meaningful once the
+  // true root is loaded: while older turns are still paginated out (`hasOlder`)
+  // the opening exchange isn't rendered, so there's nothing here to guard.
+  const protectedFirstRoundIds = useMemo(() => {
+    const ids = new Set<string>()
+    if (conversation.hasOlder) return ids
+    const msgs = conversation.messages
+    const firstUserIdx = msgs.findIndex((m) => m.role === 'user')
+    if (firstUserIdx < 0) return ids
+    // The opening round is the first question plus every reply up to the next
+    // user turn. Deletion is round-based, so a delete button on ANY of these
+    // rows would drop the whole first exchange — protect them all.
+    for (let i = firstUserIdx; i < msgs.length; i++) {
+      if (i > firstUserIdx && msgs[i].role === 'user') break
+      ids.add(msgs[i].id)
+    }
+    return ids
+  }, [conversation.messages, conversation.hasOlder])
+
   return (
     <div
       className="chat-thread flex flex-col px-[var(--layout-gutter-mobile)] sm:px-6 lg:px-8 py-8 mx-auto w-full max-w-[var(--layout-message-max-w)]"
@@ -288,13 +311,17 @@ export function MessageList({ conversation, scrollToMessageId, jumpKey }: Messag
           onBranchSwitch={handleBranchSwitch}
           onFork={handleFork}
           onDelete={
-            // §workspaces: hide the delete-round affordance on turns the member
-            // cannot delete (server enforces author-or-creator regardless). In a
-            // shared conversation: the creator moderates everything; others only
-            // their own user turns (assistant rows have no author -> hidden).
-            !conversation.workspaceId || conversation.creatorId === meId || (m.role === 'user' && m.authorId === meId)
-              ? handleDelete
-              : undefined
+            // §first-exchange: the opening question + its answer can never be
+            // deleted, whoever owns the conversation.
+            protectedFirstRoundIds.has(m.id)
+              ? undefined
+              : // §workspaces: hide the delete-round affordance on turns the member
+                // cannot delete (server enforces author-or-creator regardless). In a
+                // shared conversation: the creator moderates everything; others only
+                // their own user turns (assistant rows have no author -> hidden).
+                !conversation.workspaceId || conversation.creatorId === meId || (m.role === 'user' && m.authorId === meId)
+                ? handleDelete
+                : undefined
           }
           userMessageMarkdown={userMessageMarkdown}
         />

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -23,6 +23,7 @@
     "placeholder": "Ask anything — or paste your thinking.",
     "attach": "Attach files",
     "dropHint": "Drop files to attach",
+    "dropAnywhere": "Drop anywhere to attach",
     "addImage": "Add image",
     "more": "More",
     "voice": "Voice input",

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -23,6 +23,7 @@
     "placeholder": "Demandez ce que vous voulez — ou collez vos réflexions.",
     "attach": "Joindre des fichiers",
     "dropHint": "Déposez les fichiers à joindre",
+    "dropAnywhere": "Déposez n'importe où pour joindre",
     "addImage": "Ajouter une image",
     "more": "Plus",
     "voice": "Saisie vocale",

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -23,6 +23,7 @@
     "placeholder": "何でも聞いてください — または考えを貼り付けてください。",
     "attach": "ファイルを添付",
     "dropHint": "ドロップして添付",
+    "dropAnywhere": "どこにでもドロップして添付",
     "addImage": "画像を追加",
     "more": "その他",
     "voice": "音声入力",

--- a/src/i18n/locales/zh-Hant/chat.json
+++ b/src/i18n/locales/zh-Hant/chat.json
@@ -23,6 +23,7 @@
     "placeholder": "隨便問點什麼——或把你的思考粘進來。",
     "attach": "新增附件",
     "dropHint": "拖放檔案以上傳",
+    "dropAnywhere": "拖放到任意位置即可新增",
     "addImage": "新增圖片",
     "more": "更多",
     "voice": "語音輸入",

--- a/src/i18n/locales/zh/chat.json
+++ b/src/i18n/locales/zh/chat.json
@@ -23,6 +23,7 @@
     "placeholder": "随便问点什么——或把你的思考粘进来。",
     "attach": "添加附件",
     "dropHint": "拖放文件以上传",
+    "dropAnywhere": "拖放到任意位置即可添加",
     "addImage": "添加图片",
     "more": "更多",
     "voice": "语音输入",

--- a/src/pages/chat/ChatHome.tsx
+++ b/src/pages/chat/ChatHome.tsx
@@ -234,6 +234,32 @@ export default function ChatHome() {
   }, [t])
   const cards = useMemo(() => fisherYatesPick(SUGGESTIONS, 6), [])
 
+  // The suggestion rail is a single horizontally-scrollable row. A plain mouse
+  // wheel only scrolls vertically, so without this it can't be scrolled with the
+  // wheel at all — only by dragging / trackpad-panning. Translate a dominant
+  // vertical wheel delta into horizontal scroll, yielding back to the page once
+  // the rail reaches an edge so vertical page scroll is never trapped. Native
+  // (non-passive) listener: React attaches wheel passively, so an onWheel
+  // preventDefault would be ignored.
+  const suggestionsRailRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const el = suggestionsRailRef.current
+    if (!el) return
+    const onWheel = (e: WheelEvent) => {
+      if (el.scrollWidth <= el.clientWidth) return
+      if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return
+      // deltaMode 1 = lines (Firefox wheel) — normalise to pixels.
+      const delta = e.deltaMode === 1 ? e.deltaY * 24 : e.deltaY
+      const atStart = el.scrollLeft <= 0
+      const atEnd = el.scrollLeft + el.clientWidth >= el.scrollWidth - 1
+      if ((delta < 0 && atStart) || (delta > 0 && atEnd)) return
+      el.scrollLeft += delta
+      e.preventDefault()
+    }
+    el.addEventListener('wheel', onWheel, { passive: false })
+    return () => el.removeEventListener('wheel', onWheel)
+  }, [drawMode])
+
   // Entrance choreography — the home screen used to pop in flat. Now the
   // heading, lead, composer and suggestion cards rise + fade in sequence, with a
   // whisper-faint accent glow breathing behind the greeting for depth. All gated
@@ -417,10 +443,16 @@ export default function ChatHome() {
 
             {!drawMode && (
               <div className="mt-8 sm:mt-10 mx-auto w-full max-w-[44rem]">
-                {/* Single row, fixed-width cards, horizontally scrollable (snap).
-                    Scrollbar hidden; on phones the rail bleeds to the screen edges
-                    so the next card peeks. */}
-                <div className="flex gap-3 overflow-x-auto px-1 -mx-1 max-sm:-mx-[var(--layout-gutter-mobile)] max-sm:px-[var(--layout-gutter-mobile)] max-sm:scroll-px-[var(--layout-gutter-mobile)] pb-2 snap-x snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                {/* Single row, fixed-width cards, horizontally scrollable (snap +
+                    mouse wheel, see suggestionsRailRef). Scrollbar hidden; on phones
+                    the rail bleeds to the screen edges so the next card peeks. The
+                    top/bottom padding leaves room for each card's hover lift +
+                    shadow, which `overflow-x-auto` (which also clips the y axis)
+                    would otherwise cut off. */}
+                <div
+                  ref={suggestionsRailRef}
+                  className="flex gap-3 overflow-x-auto px-1 -mx-1 max-sm:-mx-[var(--layout-gutter-mobile)] max-sm:px-[var(--layout-gutter-mobile)] max-sm:scroll-px-[var(--layout-gutter-mobile)] pt-2 pb-2 snap-x snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                >
                   {cards.map((s) => {
                     const title = t(s.titleKey)
                     const prompt = t(s.promptKey)


### PR DESCRIPTION
Addresses four reported issues in the chat surface:

1. Protect the first Q&A from deletion (message-list.tsx) Deletion is round-based — removing either the question or its answer drops the whole exchange — and the delete affordance renders on both the user and the assistant rows. Added a `protectedFirstRoundIds` memo that, once the true root is loaded (i.e. not paginated out via `hasOlder`), derives the opening round by role: the first user turn plus every reply up to the next user turn. Those rows now receive `onDelete=undefined`, which hides the control across all three surfaces (desktop button, mobile action sheet, and confirm dialog) since they all key off `onDelete`.

2. Homepage suggestion rail: wheel scrolling + hover clipping (ChatHome.tsx)
   - The single-row `overflow-x-auto` rail ignored a vertical mouse wheel. Added a native (non-passive) wheel listener that translates a dominant vertical delta into horizontal scroll, and yields back to the page once the rail reaches an edge so page scroll is never trapped.
   - `overflow-x: auto` also clips the y axis, so each card's hover lift (`-translate-y-0.5`) and shadow were sliced off at the top. Added top padding (pt-2 pb-2) to give the hover state room.

3. Full-screen drag-and-drop for file/image uploads (composer.tsx) Replaced the composer-only drop handlers with window-level drag listeners (with a depth counter to avoid overlay flicker), so a file dropped anywhere on the page is attached through the same handleAttach path. The drop-hint overlay is now rendered full-viewport via a portal to document.body, so an ancestor's transform (e.g. ChatHome's GSAP wrapper) can't break its fixed positioning. Only one composer mounts at a time, so there is no double-handling.

4. Clear the uploaded image after sending (composer.tsx) Sending the first message from the home screen navigates to the thread, which mounts a fresh composer whose draft-file restore raced the backend's commit and re-added the just-sent image. Added a module-level `committedFileIds` set (marked on send, consulted in the restore filter) so a committed attachment can no longer bounce back into the new thread's composer.

i18n: added the `composer.dropAnywhere` string to en/zh/zh-Hant/ja/fr.

Verified: tsc --noEmit, eslint, vitest (34 passing), and a full production build all pass.