### PR TITLE
feat(chat): copy rendered formulas as LaTeX

### DIFF
--- a/src/components/chat/markdown.tsx
+++ b/src/components/chat/markdown.tsx
@@ -3,13 +3,16 @@ import {
   tokenizeMarkdown,
   inlineMarkdownToHtml,
   blockMarkdownToHtml,
+  renderMathToHtml,
   type CiteRef,
+  type MathCopyLabels,
   type MarkdownBlock,
 } from '@/lib/markdown'
 import { CodeBlock } from './code-block'
 import { MermaidDiagram } from './mermaid-diagram'
 import { cn, safeHref } from '@/lib/utils'
 import { rewriteSandboxArtifactLinks } from '@/lib/artifact-links'
+import { useMathCopy } from '@/hooks/use-math-copy'
 
 import type { ArtifactRef, Citation } from '@/types/chat'
 import {
@@ -64,6 +67,7 @@ interface MarkdownBlockViewProps {
   blockKeyPrefix?: string
   cites: CiteRef[]
   breaks: boolean
+  mathCopyLabels: MathCopyLabels
 }
 
 /**
@@ -74,17 +78,33 @@ interface MarkdownBlockViewProps {
  * semantics and the final rendered output remain identical.
  */
 const MarkdownBlockView = memo(
-  function MarkdownBlockView({ block: b, index, live, blockKeyPrefix, cites, breaks }: MarkdownBlockViewProps) {
+  function MarkdownBlockView({
+    block: b,
+    index,
+    live,
+    blockKeyPrefix,
+    cites,
+    breaks,
+    mathCopyLabels,
+  }: MarkdownBlockViewProps) {
     const blockAnim = live ? 'animate-[fade-in_500ms_var(--ease-out)_backwards]' : undefined
 
     switch (b.type) {
       case 'heading':
-        return <HeadingTag depth={b.depth ?? 2} html={inlineMarkdownToHtml(b.content, cites, breaks)} className={blockAnim} />
+        return (
+          <HeadingTag
+            depth={b.depth ?? 2}
+            html={inlineMarkdownToHtml(b.content, cites, breaks, mathCopyLabels)}
+            className={blockAnim}
+          />
+        )
       case 'paragraph':
         return (
           <p
             className={cn('leading-relaxed text-[var(--color-fg)]', blockAnim)}
-            dangerouslySetInnerHTML={{ __html: inlineMarkdownToHtml(b.content, cites, breaks) }}
+            dangerouslySetInnerHTML={{
+              __html: inlineMarkdownToHtml(b.content, cites, breaks, mathCopyLabels),
+            }}
           />
         )
       case 'list':
@@ -98,7 +118,9 @@ const MarkdownBlockView = memo(
               '[&_ul_ul]:list-[circle] [&_ul_ul]:my-0.5 [&_ol_ol]:my-0.5 [&_li_p]:my-0',
               blockAnim,
             )}
-            dangerouslySetInnerHTML={{ __html: blockMarkdownToHtml(b.content, cites, breaks) }}
+            dangerouslySetInnerHTML={{
+              __html: blockMarkdownToHtml(b.content, cites, breaks, mathCopyLabels),
+            }}
           />
         )
       case 'code':
@@ -121,16 +143,25 @@ const MarkdownBlockView = memo(
               'border-l-2 border-[var(--color-border-strong)] pl-4 text-[var(--color-fg-muted)] italic',
               blockAnim,
             )}
-            dangerouslySetInnerHTML={{ __html: inlineMarkdownToHtml(b.content, cites, breaks) }}
+            dangerouslySetInnerHTML={{
+              __html: inlineMarkdownToHtml(b.content, cites, breaks, mathCopyLabels),
+            }}
           />
         )
       case 'math':
-        return (
-          <div
-            className={cn('my-3 overflow-x-auto', blockAnim)}
-            dangerouslySetInnerHTML={{ __html: b.content }}
-          />
-        )
+        {
+          const html = renderMathToHtml(b.content, true, mathCopyLabels)
+          return html ? (
+            <div
+              className={cn('my-3 min-w-0', blockAnim)}
+              dangerouslySetInnerHTML={{ __html: html }}
+            />
+          ) : (
+            <div className={cn('my-3 overflow-x-auto whitespace-pre-wrap', blockAnim)}>
+              {`$$${b.content}$$`}
+            </div>
+          )
+        }
       case 'hr':
         return <hr className={cn('my-6 border-[var(--color-divider)]', blockAnim)} />
       case 'table':
@@ -145,7 +176,9 @@ const MarkdownBlockView = memo(
               '[&_tr:last-child_td]:border-b-0',
               blockAnim,
             )}
-            dangerouslySetInnerHTML={{ __html: blockMarkdownToHtml(b.content, cites, breaks) }}
+            dangerouslySetInnerHTML={{
+              __html: blockMarkdownToHtml(b.content, cites, breaks, mathCopyLabels),
+            }}
           />
         )
       default:
@@ -158,6 +191,7 @@ const MarkdownBlockView = memo(
     prev.blockKeyPrefix === next.blockKeyPrefix &&
     prev.cites === next.cites &&
     prev.breaks === next.breaks &&
+    prev.mathCopyLabels === next.mathCopyLabels &&
     prev.block.type === next.block.type &&
     prev.block.content === next.block.content &&
     prev.block.depth === next.block.depth &&
@@ -194,6 +228,7 @@ export const Markdown = memo(function Markdown({
   onOpenDocumentCitation,
   breaks = false,
 }: MarkdownProps) {
+  const { announcement, handleMathCopy, labels: mathCopyLabels } = useMathCopy()
   const contentWithArtifactLinks = useMemo(
     () => rewriteSandboxArtifactLinks(content, artifacts),
     [content, artifacts],
@@ -233,10 +268,17 @@ export const Markdown = memo(function Markdown({
     },
     [citations, onOpenDocumentCitation],
   )
+  const handleContentClick = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      handleMathCopy(event)
+      handleCitationClick(event)
+    },
+    [handleCitationClick, handleMathCopy],
+  )
   if (!content) return null
 
   return (
-    <div className={cn('prose-aivory', className)} onClick={handleCitationClick}>
+    <div className={cn('prose-aivory', className)} onClick={handleContentClick}>
       {blocks.map((block, index) => (
         <MarkdownBlockView
           key={index}
@@ -246,8 +288,12 @@ export const Markdown = memo(function Markdown({
           blockKeyPrefix={blockKeyPrefix}
           cites={cites}
           breaks={breaks}
+          mathCopyLabels={mathCopyLabels}
         />
       ))}
+      <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {announcement}
+      </span>
     </div>
   )
 })

--- a/src/components/chat/math-text.tsx
+++ b/src/components/chat/math-text.tsx
@@ -1,7 +1,8 @@
-import katex from 'katex'
 import { memo, useMemo } from 'react'
 import { splitMathContent } from '@/lib/math-content'
+import { renderMathToHtml } from '@/lib/markdown'
 import { cn } from '@/lib/utils'
+import { useMathCopy } from '@/hooks/use-math-copy'
 
 interface MathTextProps {
   content: string
@@ -9,6 +10,7 @@ interface MathTextProps {
 }
 
 export const MathText = memo(function MathText({ content, className }: MathTextProps) {
+  const { announcement, handleMathCopy, labels } = useMathCopy()
   const segments = useMemo(
     () => {
       const parsed = splitMathContent(content)
@@ -27,27 +29,20 @@ export const MathText = memo(function MathText({ content, className }: MathTextP
           }
           return { ...segment, value }
         }
-        try {
-          return {
-            ...segment,
-            html: katex.renderToString(segment.value, {
-              displayMode: segment.type === 'block-math',
-              throwOnError: false,
-              strict: false,
-            }),
-          }
-        } catch {
-          // KaTeX can throw non-parse errors (for example a RangeError from an
-          // adversarially deep expression). Keep the message renderable.
-          return { ...segment, html: null }
+        return {
+          ...segment,
+          html: renderMathToHtml(segment.value, segment.type === 'block-math', labels),
         }
       })
     },
-    [content],
+    [content, labels],
   )
 
   return (
-    <div className={cn('min-w-0 whitespace-pre-wrap break-words', className)}>
+    <div
+      className={cn('min-w-0 whitespace-pre-wrap break-words', className)}
+      onClick={handleMathCopy}
+    >
       {segments.map((segment, index) => {
         if (segment.type === 'text') {
           return segment.value ? <span key={index}>{segment.value}</span> : null
@@ -70,6 +65,9 @@ export const MathText = memo(function MathText({ content, className }: MathTextP
           />
         )
       })}
+      <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {announcement}
+      </span>
     </div>
   )
 })

--- a/src/hooks/use-math-copy.ts
+++ b/src/hooks/use-math-copy.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { MathCopyLabels } from '@/lib/markdown'
+import { copyText } from '@/lib/utils'
+import { toast } from '@/hooks/use-toast'
+
+const FEEDBACK_DURATION_MS = 1500
+
+function selectionIntersects(trigger: HTMLElement): boolean {
+  if (typeof window === 'undefined') return false
+  const selection = window.getSelection()
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) return false
+  try {
+    return selection.getRangeAt(0).intersectsNode(trigger)
+  } catch {
+    return false
+  }
+}
+
+function resetTrigger(trigger: HTMLElement | null) {
+  if (!trigger) return
+  trigger.removeAttribute('data-copied')
+  const label = trigger.dataset.copyLabel
+  if (label) {
+    trigger.setAttribute('aria-label', label)
+    trigger.setAttribute('title', label)
+  }
+}
+
+export function useMathCopy() {
+  const { t } = useTranslation('chat')
+  const labels = useMemo<MathCopyLabels>(
+    () => ({
+      copy: t('actions.copyLatex', { defaultValue: 'Copy LaTeX' }),
+      copied: t('actions.latexCopied', { defaultValue: 'LaTeX copied' }),
+    }),
+    [t],
+  )
+  const failedLabel = t('actions.copyLatexFailed', { defaultValue: 'Couldn’t copy the LaTeX' })
+  const [announcement, setAnnouncement] = useState('')
+  const activeTrigger = useRef<HTMLElement | null>(null)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const request = useRef(0)
+
+  const clearFeedback = useCallback(() => {
+    if (timer.current) clearTimeout(timer.current)
+    timer.current = null
+    resetTrigger(activeTrigger.current)
+    activeTrigger.current = null
+    setAnnouncement('')
+  }, [])
+
+  useEffect(
+    () => () => {
+      request.current += 1
+      if (timer.current) clearTimeout(timer.current)
+      resetTrigger(activeTrigger.current)
+    },
+    [],
+  )
+
+  const handleMathCopy = useCallback(
+    (event: MouseEvent<HTMLElement>) => {
+      if (!(event.target instanceof Element)) return
+      const trigger = event.target.closest<HTMLElement>('[data-math-copy="true"]')
+      if (!trigger || !event.currentTarget.contains(trigger) || selectionIntersects(trigger)) return
+
+      const latex = trigger.dataset.latex?.trim()
+      if (!latex) return
+      const requestID = ++request.current
+
+      void copyText(latex).then((copied) => {
+        if (requestID !== request.current) return
+        if (!copied) {
+          clearFeedback()
+          setAnnouncement(failedLabel)
+          toast.error(failedLabel)
+          timer.current = setTimeout(clearFeedback, FEEDBACK_DURATION_MS)
+          return
+        }
+
+        clearFeedback()
+        activeTrigger.current = trigger
+        trigger.dataset.copied = 'true'
+        trigger.setAttribute('aria-label', labels.copied)
+        trigger.setAttribute('title', labels.copied)
+        setAnnouncement(labels.copied)
+        timer.current = setTimeout(clearFeedback, FEEDBACK_DURATION_MS)
+      })
+    },
+    [clearFeedback, failedLabel, labels.copied],
+  )
+
+  return { announcement, handleMathCopy, labels }
+}

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -190,6 +190,9 @@
   "actions": {
     "copy": "Copy",
     "copied": "Copied",
+    "copyLatex": "Copy LaTeX",
+    "latexCopied": "LaTeX copied",
+    "copyLatexFailed": "Couldn’t copy the LaTeX",
     "exportDocx": "Export as Word",
     "exportDocxFailed": "Export failed",
     "creditsUsed": "{{credits}} credits used",

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -185,6 +185,9 @@
   "actions": {
     "copy": "Copier",
     "copied": "Copié",
+    "copyLatex": "Copier le LaTeX",
+    "latexCopied": "LaTeX copié",
+    "copyLatexFailed": "Impossible de copier le LaTeX",
     "exportDocx": "Exporter en Word",
     "exportDocxFailed": "Échec de l'exportation",
     "creditsUsed": "{{credits}} crédits utilisés",

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -185,6 +185,9 @@
   "actions": {
     "copy": "コピー",
     "copied": "コピーしました",
+    "copyLatex": "LaTeX をコピー",
+    "latexCopied": "LaTeX をコピーしました",
+    "copyLatexFailed": "LaTeX をコピーできませんでした",
     "exportDocx": "Word としてエクスポート",
     "exportDocxFailed": "エクスポートに失敗しました",
     "creditsUsed": "{{credits}} クレジット使用",

--- a/src/i18n/locales/zh-Hant/chat.json
+++ b/src/i18n/locales/zh-Hant/chat.json
@@ -185,6 +185,9 @@
   "actions": {
     "copy": "複製",
     "copied": "已複製",
+    "copyLatex": "複製 LaTeX",
+    "latexCopied": "已複製 LaTeX",
+    "copyLatexFailed": "無法複製 LaTeX",
     "exportDocx": "匯出為 Word",
     "exportDocxFailed": "匯出失敗",
     "creditsUsed": "消耗 {{credits}} 點數",

--- a/src/i18n/locales/zh/chat.json
+++ b/src/i18n/locales/zh/chat.json
@@ -185,6 +185,9 @@
   "actions": {
     "copy": "复制",
     "copied": "已复制",
+    "copyLatex": "复制 LaTeX",
+    "latexCopied": "已复制 LaTeX",
+    "copyLatexFailed": "无法复制 LaTeX",
     "exportDocx": "导出为 Word",
     "exportDocxFailed": "导出失败",
     "creditsUsed": "消耗 {{credits}} 积分",

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -217,22 +217,43 @@ export interface MarkdownBlock {
   lang?: string
 }
 
+export interface MathCopyLabels {
+  copy: string
+  copied: string
+}
+
+const DEFAULT_MATH_COPY_LABELS: MathCopyLabels = {
+  copy: 'Copy LaTeX',
+  copied: 'LaTeX copied',
+}
+
 /**
- * Render an inline markdown string to HTML (used by paragraph blocks).
- * marked v15 types this as `string | Promise<string>` — `async: false`
- * guarantees a string in practice; we runtime-assert to avoid silent
- * `[object Promise]` injection if marked extensions change behavior.
+ * Render a read-only formula as a button that retains the normalized LaTeX.
+ * The wrapper is generated here because inline markdown is inserted as HTML;
+ * keeping the source in a safely escaped data attribute lets the React surface
+ * provide one delegated copy interaction for paragraphs, lists and tables.
  */
-/**
- * Render a LaTeX fragment via KaTeX (§1.1 P0 — math output). Errors degrade to
- * the original delimited source rather than throwing.
- */
-function renderTex(tex: string, display: boolean): string {
+export function renderMathToHtml(
+  tex: string,
+  display: boolean,
+  labels: MathCopyLabels = DEFAULT_MATH_COPY_LABELS,
+): string | null {
+  const latex = tex.trim()
+  if (!latex) return null
   try {
-    return katex.renderToString(tex.trim(), { displayMode: display, throwOnError: false })
+    const rendered = katex.renderToString(latex, {
+      displayMode: display,
+      throwOnError: false,
+      strict: false,
+    })
+    return `<button type="button" class="math-copy-trigger" data-math-copy="true" data-latex="${escapeAttr(latex)}" data-copy-label="${escapeAttr(labels.copy)}" data-copied-label="${escapeAttr(labels.copied)}" data-display="${display ? 'true' : 'false'}" aria-label="${escapeAttr(labels.copy)}" title="${escapeAttr(labels.copy)}"><span class="math-copy-content">${rendered}</span></button>`
   } catch {
-    return escapeHtml(display ? `$$${tex}$$` : `$${tex}$`)
+    return null
   }
+}
+
+function renderTexOrSource(tex: string, display: boolean, labels?: MathCopyLabels): string {
+  return renderMathToHtml(tex, display, labels) ?? escapeHtml(display ? `$$${tex}$$` : `$${tex}$`)
 }
 
 function escapeHtml(s: string): string {
@@ -307,25 +328,41 @@ export function linkifyCitations(html: string, cites: CiteRef[]): string {
  * Currency like `$5 and $10` is left alone (lookbehind requires a non-space
  * before the closing `$`, and a single `$…$` span can't straddle two amounts).
  */
-function protectMath(md: string): { text: string; map: string[] } {
+function protectMath(md: string, labels?: MathCopyLabels): { text: string; map: string[] } {
   const map: string[] = []
+  const code: string[] = []
   const stash = (html: string) => {
     const i = map.length
     map.push(html)
     return `@@MATH${i}@@`
   }
-  let text = md
-  text = text.replace(/\$\$([\s\S]+?)\$\$/g, (_, tex) => stash(renderTex(tex, true)))
-  text = text.replace(/\\\[([\s\S]+?)\\\]/g, (_, tex) => stash(renderTex(tex, true)))
-  text = text.replace(/\\\(([\s\S]+?)\\\)/g, (_, tex) => stash(renderTex(tex, false)))
-  text = text.replace(/\$(?!\s)([^$\n]+?)(?<!\s)\$/g, (_, tex) => stash(renderTex(tex, false)))
+  const stashCode = (source: string) => {
+    const i = code.length
+    code.push(source)
+    return `@@CODE${i}@@`
+  }
+  // Math delimiters inside inline code are literal. Temporarily remove code
+  // spans before finding formulae, then restore them before marked parses.
+  let text = md.replace(/(`+)([\s\S]*?)\1/g, (source) => stashCode(source))
+  text = text.replace(/\$\$([\s\S]+?)\$\$/g, (_, tex) => stash(renderTexOrSource(tex, true, labels)))
+  text = text.replace(/\\\[([\s\S]+?)\\\]/g, (_, tex) => stash(renderTexOrSource(tex, true, labels)))
+  text = text.replace(/\\\(([\s\S]+?)\\\)/g, (_, tex) => stash(renderTexOrSource(tex, false, labels)))
+  text = text.replace(/\$(?!\s)([^$\n]+?)(?<!\s)\$/g, (_, tex) => stash(renderTexOrSource(tex, false, labels)))
+  text = text.replace(/@@CODE(\d+)@@/g, (_, i) => code[Number(i)] ?? '')
   return { text, map }
 }
 
-export function inlineMarkdownToHtml(md: string, cites?: CiteRef[], breaks = false): string {
+export function inlineMarkdownToHtml(
+  md: string,
+  cites?: CiteRef[],
+  breaks = false,
+  mathCopyLabels?: MathCopyLabels,
+): string {
+  // marked v15 types parseInline as `string | Promise<string>`; async:false
+  // guarantees a string in practice, with a runtime fallback below.
   // Layer 1: strip raw HTML tags from markdown source before marked sees it.
   const cleaned = stripRawHtml(md)
-  const { text, map } = protectMath(cleaned)
+  const { text, map } = protectMath(cleaned, mathCopyLabels)
   // `breaks` turns a single "\n" into <br> (soft break). Off for assistant
   // markdown (standard rendering); on for literal user input / thinking where
   // the author's line breaks are meaningful.
@@ -351,9 +388,14 @@ export function inlineMarkdownToHtml(md: string, cites?: CiteRef[], breaks = fal
  * `table` block — paragraphs/headings stay on the inline path. Same two-layer
  * defence (strip raw HTML → sanitize) and math protection.
  */
-export function blockMarkdownToHtml(md: string, cites?: CiteRef[], breaks = false): string {
+export function blockMarkdownToHtml(
+  md: string,
+  cites?: CiteRef[],
+  breaks = false,
+  mathCopyLabels?: MathCopyLabels,
+): string {
   const cleaned = stripRawHtml(md)
-  const { text, map } = protectMath(cleaned)
+  const { text, map } = protectMath(cleaned, mathCopyLabels)
   let out = marked.parse(text, { async: false, breaks })
   if (typeof out !== 'string') {
     return escapeHtml(md)
@@ -371,7 +413,7 @@ export function blockMarkdownToHtml(md: string, cites?: CiteRef[], breaks = fals
  * Tokenize markdown into a flat block list our React renderer can map over.
  *
  * Display math (`$$…$$` / `\[…\]`) is extracted FIRST, before `marked` ever
- * sees it, and emitted as standalone `math` blocks rendered straight by KaTeX.
+ * sees it, and emitted as standalone `math` blocks that retain the raw LaTeX.
  * Otherwise marked splits multi-line display math across paragraphs (or escapes
  * `\[` → `[`), which left raw LaTeX like `[ \frac{…} ]` on screen. Inline math
  * (`$…$` / `\(…\)`) stays on the per-block path in inlineMarkdownToHtml.
@@ -384,7 +426,7 @@ export function tokenizeMarkdown(md: string, breaks = false): MarkdownBlock[] {
   while ((m = displayMath.exec(md)) !== null) {
     lexInto(blocks, md.slice(lastIndex, m.index), breaks)
     const tex = (m[1] ?? m[2] ?? '').trim()
-    if (tex) blocks.push({ type: 'math', content: renderTex(tex, true) })
+    if (tex) blocks.push({ type: 'math', content: tex })
     lastIndex = m.index + m[0].length
   }
   lexInto(blocks, md.slice(lastIndex), breaks)

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1178,6 +1178,95 @@ mark.inline-thread-mark:hover {
   overflow-x: auto;
   overflow-y: hidden;
 }
+
+/* Read-only formulas are quiet copy controls. The formula remains visually
+   primary; affordance appears through cursor, hover/focus, and brief feedback. */
+.math-copy-trigger {
+  appearance: none;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  margin: 0 -0.08em;
+  padding: 0 0.08em;
+  border: 0;
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  line-height: inherit;
+  text-align: inherit;
+  vertical-align: middle;
+  cursor: copy;
+  user-select: text;
+  transition: background-color var(--duration-fast) var(--ease-out);
+}
+
+.math-copy-content {
+  display: inline-block;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.math-copy-trigger[data-display='true'] {
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 0.125rem 0.25rem;
+  text-align: center;
+}
+
+.math-copy-trigger[data-display='true'] .math-copy-content {
+  display: block;
+  width: 100%;
+}
+
+@media (hover: hover) {
+  .math-copy-trigger:hover {
+    background: var(--color-bg-muted);
+  }
+}
+
+.math-copy-trigger:active {
+  background: var(--color-accent-soft);
+}
+
+.math-copy-trigger:focus-visible {
+  outline-color: var(--color-ring);
+}
+
+.math-copy-trigger[data-copied='true'] {
+  background: var(--color-success-soft);
+}
+
+.math-copy-trigger[data-copied='true']::after {
+  content: attr(data-copied-label);
+  position: absolute;
+  z-index: var(--z-tooltip);
+  bottom: calc(100% + 0.375rem);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-xs);
+  background: var(--color-fg);
+  color: var(--color-bg);
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  line-height: 1.25;
+  white-space: nowrap;
+  pointer-events: none;
+  user-select: none;
+}
+
+.math-copy-trigger[data-display='true'][data-copied='true']::after {
+  top: 0.375rem;
+  right: 0.5rem;
+  bottom: auto;
+  left: auto;
+  transform: none;
+}
 .prose-aivory hr { border: none; border-top: 1px solid var(--color-divider); margin: 2em 0; }
 .prose-aivory table {
   width: 100%;

--- a/tests/frontend/components/chat/markdown-citations.test.tsx
+++ b/tests/frontend/components/chat/markdown-citations.test.tsx
@@ -4,6 +4,12 @@ import { describe, expect, it, vi } from 'vitest'
 import { Markdown } from '@/components/chat/markdown'
 import type { Citation } from '@/types/chat'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+}))
+
 function renderHeadingCitation(citation: Citation): string {
   return renderToStaticMarkup(
     createElement(Markdown, {

--- a/tests/frontend/components/chat/math-text.test.tsx
+++ b/tests/frontend/components/chat/math-text.test.tsx
@@ -1,7 +1,13 @@
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { MathText } from '@/components/chat/math-text'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+  }),
+}))
 
 describe('MathText', () => {
   const renderMathText = (content: string) =>
@@ -11,13 +17,32 @@ describe('MathText', () => {
     const hostile = `\\(${'{'.repeat(4_500)}x${'}'.repeat(4_500)}\\)`
     expect(() => renderMathText(hostile)).not.toThrow()
     expect(renderMathText(hostile)).toContain('x')
+    expect(renderMathText(hostile)).not.toContain('data-math-copy="true"')
+  })
+
+  it('keeps the original inline LaTeX on an accessible copy button', () => {
+    const html = renderMathText('Before \\(x^2 + "quoted" & y < z\\) after')
+
+    expect(html).toContain('type="button"')
+    expect(html).toContain('data-math-copy="true"')
+    expect(html).toContain('data-latex="x^2 + &quot;quoted&quot; &amp; y &lt; z"')
+    expect(html).toContain('data-display="false"')
+    expect(html).toContain('aria-label="Copy LaTeX"')
+  })
+
+  it('marks block formulae as display copy targets', () => {
+    const html = renderMathText('\\[\\sum_i x_i\\]')
+
+    expect(html).toContain('class="math-text-block"')
+    expect(html).toContain('data-latex="\\sum_i x_i"')
+    expect(html).toContain('data-display="true"')
   })
 
   it('consumes structural line breaks around a block formula between text', () => {
     const html = renderMathText('Before\n\\[x^2\\]\nAfter')
 
     expect(html).toContain('<span>Before</span><div class="math-text-block"')
-    expect(html).toContain('</div><span>After</span></div>')
+    expect(html).toContain('</div><span>After</span>')
   })
 
   it('does not leave a structural line break between consecutive block formulas', () => {
@@ -31,6 +56,6 @@ describe('MathText', () => {
     const html = renderMathText('Before\n\n\\[x\\]\n\nAfter')
 
     expect(html).toContain('<span>Before\n</span><div class="math-text-block"')
-    expect(html).toContain('</div><span>\nAfter</span></div>')
+    expect(html).toContain('</div><span>\nAfter</span>')
   })
 })

--- a/tests/frontend/lib/markdown-normalize.test.ts
+++ b/tests/frontend/lib/markdown-normalize.test.ts
@@ -55,3 +55,29 @@ describe('normalizeThinkingMarkdown', () => {
     expect(n).toContain('```\n**不是标题**\n```')
   })
 })
+
+describe('copyable markdown formulae', () => {
+  it('preserves inline LaTeX as safely escaped copy metadata', () => {
+    const html = inlineMarkdownToHtml('Solve \\(x^2 + "quoted" & y < z\\).')
+
+    expect(html).toContain('data-math-copy="true"')
+    expect(html).toContain('data-latex="x^2 + &quot;quoted&quot; &amp; y &lt; z"')
+    expect(html).toContain('data-display="false"')
+    expect(html).toContain('aria-label="Copy LaTeX"')
+  })
+
+  it('keeps block LaTeX raw until the React renderer adds KaTeX', () => {
+    const blocks = tokenizeMarkdown('Before\n\n$$\\sum_i x_i$$\n\nAfter')
+    const math = blocks.find((block) => block.type === 'math')
+
+    expect(math?.content).toBe('\\sum_i x_i')
+    expect(math?.content).not.toContain('katex')
+  })
+
+  it('leaves math delimiters inside inline code literal', () => {
+    const html = inlineMarkdownToHtml('Use `$x^2$` in the example.')
+
+    expect(html).toContain('<code>$x^2$</code>')
+    expect(html).not.toContain('data-math-copy="true"')
+  })
+})


### PR DESCRIPTION
## Summary

- make rendered inline and block formulas clickable
- copy the complete LaTeX source instead of rendered text
- show localized copy feedback and preserve citation interactions
- add regression coverage for formula extraction and copy behavior

## Verification

- 18 targeted frontend tests passed
- npm run typecheck passed

Closes #25